### PR TITLE
Mask password characters

### DIFF
--- a/Transcrypt.py
+++ b/Transcrypt.py
@@ -77,6 +77,7 @@ class WrongPasswordException(Exception):
 
 
 class TranscryptSaveCommand(sublime_plugin.TextCommand):
+    pwd = ""
 
     def run(self, edit):
         """Do relevant command.
@@ -85,20 +86,38 @@ class TranscryptSaveCommand(sublime_plugin.TextCommand):
         encrypt, then save.
         If encrypt on save is disabled, just save.
         """
-        def on_done(password):
-            self.view.run_command(
-                "transcrypt", {"enc": True, "password": password})
-            self.view.run_command('save')
-
         # End edit immediately because we aren't doing any editing
         self.view.end_edit(edit)
 
         if self.view.settings().get('ON_SAVE'):
-            message = "Create a Password:"
-            self.view.window().show_input_panel(
-                message, "", on_done, None, None)
+            self.view.window().show_input_panel("Enter Password:", "", self.on_done, self.on_change, self.on_cancel)
         else:
-            self.view.run_command('save')
+                self.view.run_command('save')
+
+    def on_done(self, password):
+        try:
+            if self.pwd.strip() == "":
+                panel(self.window, "No password provided")
+            else:
+                self.view.window().run_command("transcrypt", {"enc": True, "password": password})
+                self.view.window().run_command('save')
+        except ValueError:
+            pass
+
+    def on_change(self, password):
+        chg = password.replace("*","")
+        if len(password) < len(self.pwd):
+            self.pwd = self.pwd[:len(password)]
+        else:
+            self.pwd = self.pwd + chg
+        self.view.window().run_command("hide_panel")
+
+    def on_cancel(self):
+        if (self.pwd == "") :
+            pass
+        else:
+            stars = "*" * len(self.pwd)
+            self.view.window().show_input_panel("Enter Password:", stars, self.on_done, self.on_change, self.on_cancel)
 
 
 class TranscryptToggleOnSaveCommand(sublime_plugin.WindowCommand):
@@ -117,19 +136,37 @@ class TranscryptToggleOnSaveCommand(sublime_plugin.WindowCommand):
 
 
 class TranscryptPasswordCommand(sublime_plugin.WindowCommand):
-
+    pwd = ""
     def run(self, enc):
         self.enc = enc
-        message = "Create a Password:" if enc else "Enter Password:"
-        self.window.show_input_panel(message, "", self.on_done, None, None)
+        message = "Enter Password:"
+        self.window.show_input_panel(message, "", self.on_done, self.on_change, self.on_cancel)
 
     def on_done(self, password):
         try:
-            if self.window.active_view():
-                self.window.active_view().run_command(
-                    "transcrypt", {"enc": self.enc, "password": password})
+            if self.pwd.strip() == "":
+                panel(self.window, "No password provided")
+            else:
+                if self.window.active_view():
+                    self.window.active_view().run_command("transcrypt", {"enc": self.enc, "password": password})
         except ValueError:
             pass
+
+    def on_change(self, password):
+        chg = password.replace("*","")
+        if len(password) < len(self.pwd):
+            self.pwd = self.pwd[:len(password)]
+        else:
+            self.pwd = self.pwd + chg
+        self.window.run_command("hide_panel")
+
+    def on_cancel(self):
+        if (self.pwd == "") :
+            pass
+        else:
+            stars = "*" * len(self.pwd)
+            self.window.show_input_panel("Enter Password:", stars, self.on_done, self.on_change, self.on_cancel)
+
 
 
 def panel(window, message):


### PR DESCRIPTION
This commit replaces the inserted plain characters in the input panel displayed with star characters, i.e. it effectively hides the password during the interaction with the user.

Still, the commit needs improvements. For now, the only way to hide the password is to hide the input panel on each character entered/deleted (`on_change` method) and show a new input panel with star characters displayed. Hiding input panel invokes `on_cancel` method - which is bad, since ESC key also invokes the same method. it is not possible to make a separation between closing the input panel using ESC key and the logic currently implemented in `on_cancel` method. There is a way to do it using sublime's `on_query_context` method, but that requires a significant effort. Currently, it is possible to close the input panel by deleting all the characters inserted.
